### PR TITLE
Use tab

### DIFF
--- a/Menu-DrivenConsoleApp/Program.cs
+++ b/Menu-DrivenConsoleApp/Program.cs
@@ -112,7 +112,7 @@ public static class Program
             if (choice != MenuChoices.NoSelection)
             {
                 var description = GetEnumDescription(choice);
-                Console.WriteLine($"[{menuItemNumber}]:    {description}");
+                Console.WriteLine($"[{menuItemNumber}]:\t{description}");
                 menuItemNumber++;
             }
 

--- a/Menu-DrivenConsoleApp/Program.cs
+++ b/Menu-DrivenConsoleApp/Program.cs
@@ -112,7 +112,7 @@ public static class Program
             if (choice != MenuChoices.NoSelection)
             {
                 var description = GetEnumDescription(choice);
-                Console.WriteLine($"[{menuItemNumber}]:\t{description}");
+                Console.WriteLine($"[{menuItemNumber}]:{(char)ConsoleKey.Tab}{description}");
                 menuItemNumber++;
             }
 


### PR DESCRIPTION
Use tab character instead of space.
Get the tab character from ```(char)ConsoleKey.Tab``` instead of ```\t```.